### PR TITLE
Add `gradient(sym=True)` and `math.special.sym()`

### DIFF
--- a/tensortrax/_evaluate.py
+++ b/tensortrax/_evaluate.py
@@ -100,7 +100,7 @@ def jacobian(fun, wrt=0, ntrax=0, parallel=False, full_output=False):
     return evaluate_jacobian
 
 
-def gradient(fun, wrt=0, ntrax=0, parallel=False, full_output=False):
+def gradient(fun, wrt=0, ntrax=0, parallel=False, full_output=False, sym=False):
     "Evaluate the gradient of a scalar-valued function."
 
     def evaluate_gradient(*args, **kwargs):
@@ -112,6 +112,10 @@ def gradient(fun, wrt=0, ntrax=0, parallel=False, full_output=False):
         fx = np.zeros((1, *t.trax))
         dfdx = np.zeros((t.size, *t.trax))
         δx = Δx = np.eye(t.size)
+
+        if sym:
+            idx_off_diag = {1: None, 3: [1], 6: [1, 2, 4]}[t.size]
+            δx[idx_off_diag] /= 2
 
         def kernel(a, wrt, δx, Δx, ntrax, args, kwargs):
             args, kwargs = add_tensor(args, kwargs, wrt, δx[a], Δx[a], ntrax)
@@ -143,7 +147,7 @@ def gradient(fun, wrt=0, ntrax=0, parallel=False, full_output=False):
     return evaluate_gradient
 
 
-def hessian(fun, wrt=0, ntrax=0, parallel=False, full_output=False):
+def hessian(fun, wrt=0, ntrax=0, parallel=False, full_output=False, sym=False):
     "Evaluate the hessian of a scalar-valued function."
 
     def evaluate_hessian(*args, **kwargs):
@@ -156,6 +160,10 @@ def hessian(fun, wrt=0, ntrax=0, parallel=False, full_output=False):
         dfdx = np.zeros((t.size, *t.trax))
         d2fdx2 = np.zeros((t.size, t.size, *t.trax))
         δx = Δx = np.eye(t.size)
+
+        if sym:
+            idx_off_diag = {1: None, 3: [1], 6: [1, 2, 4]}[t.size]
+            δx[idx_off_diag] /= 2
 
         def kernel(a, b, wrt, δx, Δx, ntrax, args, kwargs):
             args, kwargs = add_tensor(args, kwargs, wrt, δx[a], Δx[b], ntrax)

--- a/tensortrax/math/_special/__init__.py
+++ b/tensortrax/math/_special/__init__.py
@@ -8,4 +8,12 @@ r"""
                                 ╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝  
 """
 
-from ._special_tensor import dev, tresca, von_mises, triu_1d, from_triu_1d, from_triu_2d
+from ._special_tensor import (
+    dev,
+    sym,
+    tresca,
+    von_mises,
+    triu_1d,
+    from_triu_1d,
+    from_triu_2d,
+)

--- a/tensortrax/math/_special/_special_tensor.py
+++ b/tensortrax/math/_special/_special_tensor.py
@@ -10,16 +10,21 @@ r"""
 
 import numpy as np
 
-# from ..._tensor import Tensor, einsum, matmul, f, δ, Δ, Δδ
-from .._math_tensor import trace, ddot, sqrt
+# from ..._tensor import Tensor, transpose,  matmul, f, δ, Δ, Δδ
+from .._math_tensor import trace, ddot, sqrt, transpose
 from .. import _math_array as array
 from .._linalg import _linalg_tensor as linalg
 
 
 def dev(A):
-    "Deviatoric Part of a Tensor."
+    "Deviatoric part of a Tensor."
     dim = A.shape[0]
     return A - trace(A) / dim * array.eye(A)
+
+
+def sym(A):
+    "Symmetric part of a Tensor."
+    return (A + transpose(A)) / 2
 
 
 def tresca(A):

--- a/tensortrax/math/_special/_special_tensor.py
+++ b/tensortrax/math/_special/_special_tensor.py
@@ -40,7 +40,9 @@ def triu_1d(A):
 
 
 def _from_triu_helper(A):
-    size_from_dim = np.array([d**2 / 2 + d / 2 for d in np.arange(4)], dtype=int)
+    size_from_dim = np.array(
+        [np.sum(1 + np.arange(d)) for d in np.arange(4)], dtype=int
+    )
     size = A.shape[0]
     dim = np.where(size_from_dim == size)[0][0]
     idx = np.zeros((dim, dim), dtype=int)

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -10,6 +10,21 @@ def neo_hooke(F):
     return (J ** (-2 / 3) * I1 - 3) / 2
 
 
+def neo_hooke_sym(C):
+    C = (C + C.T()) / 2
+    I3 = tm.linalg.det(C)
+    I1 = tm.trace(C)
+    return (I3 ** (-1 / 3) * I1 - 3) / 2
+
+
+def neo_hooke_sym_triu(C):
+    C = tm.special.from_triu_1d(C)
+    C = (C + C.T()) / 2
+    I3 = tm.linalg.det(C)
+    I1 = tm.trace(C)
+    return (I3 ** (-1 / 3) * I1 - 3) / 2
+
+
 def ogden(F, mu=1, alpha=2):
     C = F.T() @ F
     J = tm.linalg.det(F)
@@ -99,7 +114,26 @@ def test_repeated_eigvals():
     assert np.allclose(d2wdf2, d2WdF2)
 
 
+def test_sym():
+
+    F = (np.eye(3).ravel() + np.arange(9) / 10).reshape(3, 3)
+    C = F.T @ F
+
+    S = 2 * tr.gradient(neo_hooke_sym)(C)
+    D = 4 * tr.hessian(neo_hooke_sym)(C)
+
+    s6 = tr.gradient(neo_hooke_sym_triu, sym=True)(tm.special.triu_1d(C))
+    d6 = tr.hessian(neo_hooke_sym_triu, sym=True)(tm.special.triu_1d(C))
+
+    s = 2 * tm.special.from_triu_1d(s6)
+    d = 4 * tm.special.from_triu_2d(d6)
+
+    assert np.allclose(S, s)
+    assert np.allclose(D, d)
+
+
 if __name__ == "__main__":
     test_function_gradient_hessian()
     test_repeated_eigvals()
     test_trig()
+    test_sym()

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -66,7 +66,12 @@ def test_math():
     for fun in [tm.linalg.det, tm.linalg.inv]:
         assert np.allclose(fun(F), fun(T).x)
 
-    for fun in [tm.special.dev, tm.special.tresca, tm.special.von_mises]:
+    for fun in [
+        tm.special.dev,
+        tm.special.tresca,
+        tm.special.von_mises,
+        tm.special.sym,
+    ]:
         fun(T)
 
     assert tm.linalg.eigvalsh(T).shape == (3,)


### PR DESCRIPTION
Also implement `hessian(sym=True)`. 

### Warning
Ensure to make the input tensor symmetric to get a full-symmetric output. Major-symmetry of the hessian is due to the scalar-valued function; minor-symmetry must be enforced by a symmetric tensor inside the function.

```python
def neo_hooke_sym(C):
    C = tm.special.sym(C) # important!
    I3 = tm.linalg.det(C)
    I1 = tm.trace(C)
    return (I3 ** (-1 / 3) * I1 - 3) / 2
```