### PR TITLE
`math.external()`: Obtain shape of `x` from given `indices="ij"`

### DIFF
--- a/src/tensortrax/__about__.py
+++ b/src/tensortrax/__about__.py
@@ -2,4 +2,4 @@
 tensorTRAX: Math on (Hyper-Dual) Tensors with Trailing Axes.
 """
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/src/tensortrax/math/_math_tensor.py
+++ b/src/tensortrax/math/_math_tensor.py
@@ -325,7 +325,7 @@ def split(ary, indices_or_sections, axis=0):
         return np.split(ary, indices_or_sections=indices_or_sections, axis=axis)
 
 
-def external(x, function, gradient, hessian, *args, **kwargs):
+def external(x, function, gradient, hessian, indices="ij", *args, **kwargs):
     """Evaluate the Tensor returned by an external scalar-valued function, evaluated at
     a given value `x`, with provided gradient and hessian which operates on the values
     of a tensor and optional arguments. All math methods inside the external
@@ -341,16 +341,15 @@ def external(x, function, gradient, hessian, *args, **kwargs):
     def gvp(g, v, ntrax):
         "Evaluate the gradient-vector product."
 
-        ij = "ijklmnpqrstuvwxyz"[: len(g.shape) - ntrax]
+        ij = indices.lower()
 
         return einsum(f"{ij}...,{ij}...->...", g, v)
 
     def hvp(h, v, u, ntrax):
         "Evaluate the hessian-vectors product."
 
-        ijkl = "ijklmnpqrstuvwxyz"[: len(h.shape) - ntrax]
-        ij = ijkl[: len(ijkl) // 2]
-        kl = ijkl[len(ijkl) // 2 :]
+        ij = indices.lower()
+        kl = indices.upper()
 
         return einsum(f"{ij}{kl}...,{ij}...,{kl}...->...", h, v, u)
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -24,6 +24,7 @@ def neo_hooke_ext(F):
         function=tr.function(W, ntrax=F.ntrax),
         gradient=tr.gradient(W, ntrax=F.ntrax),
         hessian=tr.hessian(W, ntrax=F.ntrax),
+        indices="ij",
     )
 
 


### PR DESCRIPTION
because the trailing axes include dual axes and hence, the shape of `x` can't be detected