### PR TITLE
Make the transpose method a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import tensortrax.math as tm
 
 
 def fun(F, mu=1):
-    C = F.T() @ F
+    C = F.T @ F
     I1 = tm.trace(C)
     J = tm.linalg.det(F)
     return mu / 2 * (J ** (-2 / 3) * I1 - 3)
@@ -67,7 +67,7 @@ J = tr.Tensor(z, ntrax=1)
 
 def neo_hooke(F, mu=1):
     "Strain energy function of the Neo-Hookean material formulation."
-    C = F.T() @ F
+    C = F.T @ F
     I3 = tm.linalg.det(C)
     return mu * (I3 ** (-1 / 3) * tm.trace(C) - 3) / 2
 
@@ -235,7 +235,7 @@ from tensortrax.math import trace
 
 x = np.eye(3) + np.arange(9).reshape(3, 3) / 10
 F = Tensor(x=x, δx=δF_12, Δx=ΔF_23, Δδx=None)
-I1_C = trace(F.T() @ F)
+I1_C = trace(F.T @ F)
 ```
 
 The function as well as the gradient and hessian components are accessible as:
@@ -249,7 +249,7 @@ A_1223 = Δδ(I1_C)
 To obtain full gradients and hessians of scalar-valued functions in one function call, `tensortrax` provides helpers (decorators) which handle the multiple function calls.
 
 ```python
-fun = lambda F: trace(F.T() @ F)
+fun = lambda F: trace(F.T @ F)
 
 func = tr.function(fun)(x)
 grad = tr.gradient(fun)(x)
@@ -259,7 +259,7 @@ hess = tr.hessian(fun)(x)
 For tensor-valued functions, use `jacobian()` instead of `gradient()`.
 
 ```python
-fun = lambda F: F.T() @ F
+fun = lambda F: F.T @ F
 
 jac = tr.jacobian(fun)(x)
 ```

--- a/src/tensortrax/__about__.py
+++ b/src/tensortrax/__about__.py
@@ -2,4 +2,4 @@
 tensorTRAX: Math on (Hyper-Dual) Tensors with Trailing Axes.
 """
 
-__version__ = "0.16.1"
+__version__ = "0.17.0"

--- a/src/tensortrax/_tensor.py
+++ b/src/tensortrax/_tensor.py
@@ -309,6 +309,7 @@ class Tensor:
         data = self.x.__repr__()
         return "\n".join([header, *metadata, "", data])
 
+    @property
     def T(self):
         return transpose(self)
 

--- a/tests/test_dual2real.py
+++ b/tests/test_dual2real.py
@@ -13,7 +13,7 @@ def test_dual2real():
     F.init(hessian=True)
 
     # perform some math operations
-    C = F.T() @ F
+    C = F.T @ F
     J = tm.linalg.det(F)
     W = tm.trace(J ** (-2 / 3) * C) - 3
     eta = 1 - 1 / 3 * tm.tanh(W / 8)

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -5,14 +5,14 @@ import tensortrax.math as tm
 
 
 def neo_hooke(F):
-    C = F.T() @ F
+    C = F.T @ F
     I1 = tm.trace(C)
     J = tm.linalg.det(F)
     return (J ** (-2 / 3) * I1 - 3) / 2
 
 
 def neo_hooke_sym(C):
-    C = (C + C.T()) / 2
+    C = (C + C.T) / 2
     I3 = tm.linalg.det(C)
     I1 = tm.trace(C)
     return (I3 ** (-1 / 3) * I1 - 3) / 2
@@ -28,14 +28,14 @@ def neo_hooke_sym_triu(C, statevars):
 
 
 def ogden(F, mu=1, alpha=2):
-    C = F.T() @ F
+    C = F.T @ F
     J = tm.linalg.det(F)
     λ = tm.sqrt(tm.linalg.eigvalsh(J ** (-2 / 3) * C))
     return tm.sum(1 / alpha * (λ**alpha - 1))
 
 
 def trig(F):
-    C = F.T() @ F
+    C = F.T @ F
     I1 = tm.trace(C)
     return tm.sin(I1) + tm.cos(I1) + tm.tan(I1) + tm.tanh(I1)
 

--- a/tests/test_hessian_vector_product.py
+++ b/tests/test_hessian_vector_product.py
@@ -9,14 +9,14 @@ def simple(F):
 
 
 def neo_hooke(F):
-    C = F.T() @ F
+    C = F.T @ F
     I1 = tm.trace(C)
     J = tm.linalg.det(F)
     return (J ** (-2 / 3) * I1 - 3) / 2
 
 
 def ogden(F, mu=1, alpha=2):
-    C = F.T() @ F
+    C = F.T @ F
     J = tm.linalg.det(F)
     λ = tm.sqrt(tm.linalg.eigvalsh(J ** (-2 / 3) * C))
     return tm.sum(1 / alpha * (λ**alpha - 1))

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -8,7 +8,7 @@ def simple(F):
 
 
 def right_cauchy_green(F):
-    return F.T() @ F
+    return F.T @ F
 
 
 def test_jacobian():

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -12,9 +12,9 @@ def test_math():
 
     C = F.T @ F
 
-    assert np.allclose(tr.f(T.T() @ F), C)
+    assert np.allclose(tr.f(T.T @ F), C)
     assert np.allclose(tr.f(F.T @ T), C)
-    assert np.allclose(tr.f(T.T() @ T), C)
+    assert np.allclose(tr.f(T.T @ T), C)
 
     assert T[0].shape == (3,)
 
@@ -180,7 +180,7 @@ def test_eigh():
 def test_triu():
     F = np.tile((np.eye(3) + np.arange(1, 10).reshape(3, 3) / 10).reshape(3, 3, 1), 10)
     V = tr.Tensor(F, F, F, ntrax=1)
-    T = V.T() @ V
+    T = V.T @ V
 
     t = tm.special.triu_1d(T)
     assert t.shape == (6,)

--- a/tests/test_take.py
+++ b/tests/test_take.py
@@ -5,7 +5,7 @@ import tensortrax.math as tm
 
 
 def neo_hooke(F):
-    C = F.T() @ F
+    C = F.T @ F
     I1 = tm.trace(C)
     J = tm.linalg.det(F)
     return (J ** (-2 / 3) * I1 - 3) / 2, F


### PR DESCRIPTION
Idea by @ZAARAOUI999: Decorate the transpose-method as `@property` as discussed in #96.

This changes the transpose method of a tensor `Tensor(x).T()` to NumPy-syntax `Tensor(x).T`

closes #78 
closes #97

**WARNING**: *Breaks backward compatibility*.