### PR TITLE
Fix access to private submodules `math._linalg` and `math._special`

### DIFF
--- a/src/tensortrax/__about__.py
+++ b/src/tensortrax/__about__.py
@@ -2,4 +2,4 @@
 tensorTRAX: Math on (Hyper-Dual) Tensors with Trailing Axes.
 """
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"

--- a/src/tensortrax/math/_linalg.py
+++ b/src/tensortrax/math/_linalg.py
@@ -1,0 +1,3 @@
+from .linalg import _det, _inv, _pinv, det, eigh, eigvalsh, expm, inv, pinv
+
+__all__ = ["_det", "_inv", "_pinv", "det", "eigh", "eigvalsh", "expm", "inv", "pinv"]

--- a/src/tensortrax/math/_special.py
+++ b/src/tensortrax/math/_special.py
@@ -1,0 +1,21 @@
+from .special import (
+    ddot,
+    dev,
+    from_triu_1d,
+    from_triu_2d,
+    sym,
+    tresca,
+    triu_1d,
+    von_mises,
+)
+
+__all__ = [
+    "ddot",
+    "dev",
+    "from_triu_1d",
+    "from_triu_2d",
+    "sym",
+    "tresca",
+    "triu_1d",
+    "von_mises",
+]


### PR DESCRIPTION
they are now located in `math.linalg` and `math.special`

This fixes old versions of FElupe with tensortrax.