### PR TITLE
flip the variations in `math.real_to_dual(A, x)`

### DIFF
--- a/src/tensortrax/__about__.py
+++ b/src/tensortrax/__about__.py
@@ -2,4 +2,4 @@
 tensorTRAX: Math on (Hyper-Dual) Tensors with Trailing Axes.
 """
 
-__version__ = "0.21.1"
+__version__ = "0.21.2"

--- a/src/tensortrax/_tensor.py
+++ b/src/tensortrax/_tensor.py
@@ -387,7 +387,7 @@ def real_to_dual(A, x, mul=None):
         x=mul(f(A), f(x)) * np.nan,
         δx=mul(f(A), δ(x)),
         Δx=mul(f(A), Δ(x)),
-        Δδx=mul(Δ(A), δ(x)) + mul(f(A), Δδ(x)),
+        Δδx=mul(δ(A), Δ(x)) + mul(f(A), Δδ(x)),
         ntrax=A.ntrax,
     )
 


### PR DESCRIPTION
because `δ(x)` is always available