### PR TITLE
Fix missing `eigh` dual values

### DIFF
--- a/src/tensortrax/__about__.py
+++ b/src/tensortrax/__about__.py
@@ -2,4 +2,4 @@
 tensorTRAX: Math on (Hyper-Dual) Tensors with Trailing Axes.
 """
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"


### PR DESCRIPTION
Previously, only the first variation of `eigh(C)` was evaluated. This PR adds the second variation for the eigenvalue decomposition.