### PR TITLE
Fix `math.linalg.eigvalsh()` and  `math.linalg.eigh()` for arrays

### DIFF
--- a/src/tensortrax/__about__.py
+++ b/src/tensortrax/__about__.py
@@ -2,4 +2,4 @@
 tensorTRAX: Math on (Hyper-Dual) Tensors with Trailing Axes.
 """
 
-__version__ = "0.25.0"
+__version__ = "0.25.1"

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -76,8 +76,11 @@ def test_math():
     C = F.T @ F
     V = tr.Tensor(C)
 
-    for fun in [tm.linalg.det, tm.linalg.inv]:
+    for fun in [tm.linalg.det, tm.linalg.inv, tm.linalg.eigvalsh]:
         assert np.allclose(fun(C), fun(V).x)
+
+    for fun in [tm.linalg.eigh]:
+        assert np.all([np.allclose(x, y.x) for x, y in zip(fun(C), fun(V))])
 
     for fun in [
         tm.special.dev,


### PR DESCRIPTION
because these two functions were only implemented for tensors. Taking partial derivatives could raise an error if the input argument changes from a tensor to an array. This is fixed in this PR.