### PR TITLE
Fix `Tensor.init(gradient=True, δx=δx)`

### DIFF
--- a/src/tensortrax/_tensor.py
+++ b/src/tensortrax/_tensor.py
@@ -242,38 +242,23 @@ class Tensor:
         """Re-Initialize tensor with dual values to keep track of the
         hessian and/or the gradient."""
 
-        # if gradient and not hessian:
-        #     # add additional element-wise acting axes for dual values
-        #     self._add(ndual=len(self.shape))
-
-        #     # create the dual values
-        #     if δx is None or isinstance(δx, bool):
-        #         shape = (*self.shape, *self.shape)
-        #         if len(shape) == 0:
-        #             shape = (1,)
-        #         if δx is False:
-        #             δx = np.zeros(self.size**2).reshape(shape)
-        #         else:
-        #             δx = np.eye(self.size).reshape(shape)
-        #         Δx = δx.copy()
-
-        if gradient:
-            # add additional trailing axes for dual values
+        if gradient and not hessian:
+            # add additional element-wise acting axes for dual values
             self._add(ndual=len(self.shape))
 
             # create the dual values
-            ones = np.ones(len(self.shape), dtype=int)
-
             if δx is None or isinstance(δx, bool):
-                shape = (*self.shape, *ones)
+                shape = (*self.shape, *self.shape)
                 if len(shape) == 0:
                     shape = (1,)
                 if δx is False:
-                    δx = np.zeros(self.size).reshape(shape)
+                    δx = np.zeros(self.size**2).reshape(shape)
                 else:
                     δx = np.eye(self.size).reshape(shape)
+                
             else:
                 δx = δx.reshape(*self.shape, *self.trax)
+                Δx = δx.copy()
 
         elif hessian:
             # add additional trailing axes for dual values

--- a/src/tensortrax/_tensor.py
+++ b/src/tensortrax/_tensor.py
@@ -255,10 +255,11 @@ class Tensor:
                     δx = np.zeros(self.size**2).reshape(shape)
                 else:
                     δx = np.eye(self.size).reshape(shape)
-                
+
             else:
                 δx = δx.reshape(*self.shape, *self.trax)
-                Δx = δx.copy()
+
+            Δx = δx.copy()
 
         elif hessian:
             # add additional trailing axes for dual values

--- a/tests/test_hessian_vector_product.py
+++ b/tests/test_hessian_vector_product.py
@@ -50,5 +50,17 @@ def test_hvp():
             assert not np.any(np.isnan(hvp))
 
 
+def test_gvp():
+    F = np.diag([2, 1.15, 1.15])
+    F[:, 0] += np.array([0, -0.15, -0.15])
+    δF = np.vstack([np.zeros(3), np.zeros(3), np.array([-0.04, 0.04, 0.04])])
+
+    δψ = tr.gradient_vector_product(neo_hooke)(F, δx=δF)
+    δψ_reference = tm.special.ddot(tr.gradient(neo_hooke)(F), δF)
+
+    assert np.isclose(δψ, δψ_reference)
+
+
 if __name__ == "__main__":
     test_hvp()
+    test_gvp()


### PR DESCRIPTION
add a missing reshape as already implemented for `Tensor.init(hessian=True, δx=δx, Δx=Δx)`. This fixes `gradient_vector_product()`.