### PR TITLE
Update gh-action for tests and codecov

### DIFF
--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -14,18 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.13"]
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test with tox
       run: |
         pip install tox
         tox -- --cov tensortrax --cov-report xml --cov-report term
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
       if: ${{ matrix.python-version == '3.13' }}
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/tensortrax/__about__.py
+++ b/src/tensortrax/__about__.py
@@ -2,4 +2,4 @@
 tensorTRAX: Math on (Hyper-Dual) Tensors with Trailing Axes.
 """
 
-__version__ = "0.26.1"
+__version__ = "0.26.2"


### PR DESCRIPTION
Only test on Python min. and max. supported versions and update the gh-action to the latest versions.